### PR TITLE
Add link to the Problem-Solving Zoom Issues document

### DIFF
--- a/content/online-services.md
+++ b/content/online-services.md
@@ -57,6 +57,11 @@ feature and wait for the usher to call on you.
   </ul>
 </details>
 
+<details>
+  <summary>Having trouble with Zoom?</summary>
+  <p>Check out our <a href="https://docs.google.com/document/d/1MExTk6okg_J-DLE5nTNDSr8zRliVzqWJxdWcZcl4_rU/edit?usp=sharing" rel="external" target="_blank">Problem-solving Zoom Issues</a> document.</p>
+</details>
+
 ## Sunday School
 
 Several of our Sunday School teachers are holding their classes online. If

--- a/sass/assets/style.sass
+++ b/sass/assets/style.sass
@@ -81,9 +81,12 @@ article
     padding: 1rem 2em
 
 details
+  margin: 1em 0
   summary
     cursor: pointer
     text-decoration: underline
+  summary + *
+    margin-top: 0
 
 dl
   display: flex


### PR DESCRIPTION
I'm adding a link on the Online Services page to a problem-solving document that Pam prepared. I already updated the sharing settings of the document so that anyone can *view* (not *edit*) it. Since this page already has a lot of information on it and since most people won't need to use this document, I opted to put it inside an expandable section (similar to the "raise hand" instructions).

Default view:
![Screenshot from 2022-08-14 19-55-47](https://user-images.githubusercontent.com/1088389/184569798-d84f3a2a-64f4-46d0-8275-e0fae4350400.png)
Expanded:
![Screenshot from 2022-08-14 19-55-53](https://user-images.githubusercontent.com/1088389/184569796-4a8ff769-f0f2-4172-8886-922eef33bc9f.png)
And the link takes you to: https://docs.google.com/document/d/1MExTk6okg_J-DLE5nTNDSr8zRliVzqWJxdWcZcl4_rU/edit?usp=sharing